### PR TITLE
linux-firmware: fix rt73-usb-firmware package

### DIFF
--- a/package/firmware/linux-firmware/mediatek.mk
+++ b/package/firmware/linux-firmware/mediatek.mk
@@ -35,9 +35,9 @@ define Package/rt61-pci-firmware/install
 endef
 $(eval $(call BuildPackage,rt61-pci-firmware))
 
-Package/rt73-pci-firmware = $(call Package/firmware-default,Ralink RT2573 firmware)
+Package/rt73-usb-firmware = $(call Package/firmware-default,Ralink RT2573 firmware)
 define Package/rt73-usb-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rt73.bin $(1)/lib/firmware/
 endef
-$(eval $(call BuildPackage,rt73-pci-firmware))
+$(eval $(call BuildPackage,rt73-usb-firmware))


### PR DESCRIPTION
Some parts of this package were named rt73-pci-firmware before which
looks like a copy and past error. This renames all parts to rt73-usb-
firmware and then the firmware gets build and the dependencies from the
package with the kernel module are also working correctly.

This fixes #22069

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>


git-svn-id: svn://svn.openwrt.org/openwrt/trunk@49037 3c298f89-4303-0410-b956-a3cf2f4a3e73